### PR TITLE
bind to LocalPort 5060

### DIFF
--- a/SIP/check_sip_options
+++ b/SIP/check_sip_options
@@ -125,13 +125,18 @@ for (my $i=0; $i < $retries; $i++){
                 Proto    => 'udp',
                 PeerPort => $baseport,
                 PeerAddr => $opt_H,
-		LocalAddr => $opt_I,
+                LocalAddr => $opt_I,
+                LocalPort => 5060,
+                ReusePort => 1,
+
                 ) or die "Could not create socket: $!\n";
 	}else{
 	        $sock = IO::Socket::INET->new(
 	        Proto    => 'udp',
 	        PeerPort => $baseport,
 	        PeerAddr => $opt_H,
+            LocalPort => 5060,
+            ReusePort => 1,
 	        ) or die "Could not create socket: $!\n";
 	}
 	$recvthread = threads->new( \&recive_rtpproxy_request);


### PR DESCRIPTION
Due to firewall rules I need to bind the check to local port 5060
to avoid conflicts between check instances running parallel ReusePort is required

Regards